### PR TITLE
Adopt release-workflow to new dependabot-automerge commit status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
           SHA=$(git rev-parse HEAD)
-          gh api repos/projectnessie/nessie-antlr-runtime/commits/${SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith("Release") or startswith("Report") | not ) | .conclusion // "pending" ] | unique == ["success"] or unique == []) then "OK" else error("Commit checks are not OK") end'
+          gh api repos/projectnessie/nessie-antlr-runtime/commits/${SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith("Release") or startswith("Dependabot ") or startswith("Report") | not ) | .conclusion // "pending" ] | unique == ["success"] or unique == []) then "OK" else error("Commit checks are not OK") end'
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3


### PR DESCRIPTION
The commit status of the new Dependabot Automerge WF needs to be ignored
during the commit status check.