### PR TITLE
Use the `NESSIE_BUILDER` secret to auto-merge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -84,7 +84,8 @@ jobs:
       - name: "Merge pull request"
         uses: "actions/github-script@v6"
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          # Use the NESSIE_BUILDER secret to tigger CI on main branch
+          github-token: "${{ secrets.NESSIE_BUILDER }}"
           script: |
             const pullRequest = context.payload.workflow_run.pull_requests[0]
             const repository = context.repo


### PR DESCRIPTION
... because the default `GITHUB_TOKEN` does not trigger other workflows,
like CI on the main branch.